### PR TITLE
load projects and load batches dynamically calculates the number of f…

### DIFF
--- a/src/Canary/src/ProjectPage/ProjectPage.tsx
+++ b/src/Canary/src/ProjectPage/ProjectPage.tsx
@@ -18,7 +18,7 @@ export interface Project {
   projectID: string;
   projectName: string;
   userID: string;
-  numberOfFiles: number;
+  numberOfBatches: number;
   lastUpdated: string;
   settings?: unknown;
 }

--- a/src/Canary/src/ProjectPage/Tabs/DatasetTab.tsx
+++ b/src/Canary/src/ProjectPage/Tabs/DatasetTab.tsx
@@ -101,8 +101,8 @@ export const DatasetTab: React.FC<{ project: Project | null }> = () => {
                 </IconButton>
 
                 {/* header counts */}
-                <Typography variant="subtitle2" sx={{ position: 'absolute', top: 12, left: 16 }}>
-                  {b.numberOfAnnotatedFiles}/{b.numberOfTotalFiles}
+                <Typography variant="subtitle1" sx={{ position: 'absolute', top: 12, left: 16 }}>
+                  {b.numberOfTotalFiles} {b.numberOfTotalFiles === 1 ? "image" : "images"}
                 </Typography>
 
                 {/* centered bold name */}

--- a/src/Canary/src/ProjectPage/Tabs/datasetTabHandler.ts
+++ b/src/Canary/src/ProjectPage/Tabs/datasetTabHandler.ts
@@ -6,7 +6,6 @@ export interface Batch {
   batchName: string;
   projectID: string;
   numberOfTotalFiles: number;
-  numberOfAnnotatedFiles: number;
 }
 
 function projectServiceUrl() {
@@ -41,21 +40,6 @@ export async function deleteBatch(batchID: string): Promise<void> {
 
 // --- Helpers ---
 
-function isRecord(v: unknown): v is Record<string, unknown> {
-  return typeof v === 'object' && v !== null;
-}
-
-function firstDefined<T = unknown>(obj: unknown, keys: string[], fallback?: T): T | undefined {
-  if (!isRecord(obj)) return fallback;
-  for (const k of keys) {
-    if (Object.prototype.hasOwnProperty.call(obj, k)) {
-      const val = obj[k];
-      if (val !== undefined && val !== null) return val as T;
-    }
-  }
-  return fallback;
-}
-
 function toNumber(v: unknown, def = 0): number {
   if (typeof v === 'number') return v;
   if (typeof v === 'string') {
@@ -70,20 +54,13 @@ function toStringMaybe(v: unknown, def = ''): string {
 }
 
 function normalizeBatch(raw: unknown): Batch {
-  const batchID = toStringMaybe(firstDefined(raw, ['batchID', 'batchId', 'id', 'batch_id']) ?? '');
-  const batchName = toStringMaybe(firstDefined(raw, ['batchName', 'name', 'batch_name']) ?? '');
-  const projectID = toStringMaybe(firstDefined(raw, ['projectID', 'projectId', 'project_id']) ?? '');
-
-  const numberOfTotalFiles = toNumber(firstDefined(raw, ['numberOfTotalFiles', 'number_of_total_files', 'totalFiles', 'total_files', 'numberOfFiles']), 0);
-
-  const numberOfAnnotatedFiles = toNumber(firstDefined(raw, ['numberOfAnnotatedFiles', 'number_of_annotated_files', 'annotatedFiles', 'annotated_files', 'numberOfAnnotated']), 0);
-
+  // This function extracts and normalizes the fields for a Batch object from raw API data.
+  const obj = raw as Record<string, unknown>;
   return {
-    batchID,
-    batchName,
-    projectID,
-    numberOfTotalFiles,
-    numberOfAnnotatedFiles,
+    batchID: toStringMaybe(obj['batchID']),
+    batchName: toStringMaybe(obj['batchName']),
+    projectID: toStringMaybe(obj['projectID']),
+    numberOfTotalFiles: toNumber(obj['numberOfTotalFiles']),
   };
 }
 

--- a/src/Canary/src/ProjectsPage/ProjectsPage.tsx
+++ b/src/Canary/src/ProjectsPage/ProjectsPage.tsx
@@ -12,7 +12,7 @@ export interface Project {
   projectID: string;
   projectName: string;
   userID: string;
-  numberOfFiles: number;
+  numberOfBatches: number;
   lastUpdated: string;
   settings?: unknown;
 }
@@ -254,7 +254,7 @@ const ProjectsPage: React.FC = () => {
                 </Typography>
                 <Box sx={{ position: 'absolute', bottom: 16, left: 0, right: 0 }}>
                   <Typography variant="subtitle1" sx={{ fontWeight: 'medium', fontSize: '1.2rem' }}>
-                    {project.numberOfFiles} files
+                    {project.numberOfBatches} {project.numberOfBatches === 1 ? "batch" : "batches"}
                   </Typography>
                 </Box>
               </Paper>

--- a/src/services/golang-project-service/README.md
+++ b/src/services/golang-project-service/README.md
@@ -7,7 +7,6 @@
 | POST   | /projects                           | Creates a new project.                        | { "userID": "string", "projectName": "string" }                           |
 | PUT    | /projects/{projectID}               | Renames a project.                            | { "newProjectName": "string" }                                            |
 | DELETE | /projects/{projectID}               | Deletes a project.                            | None                                                                      |
-| PATCH  | /projects/{projectID}/numberoffiles | Increments the number of files in a project.  | { "quantity": int }                                                       |
 | PATCH   | /projects/{projectID}/settings      | Updates project settings.                     | { "tagLabels": { "keyPoints": ["string"], "boundingBoxes": ["string"] } } |
 
 # Batch Requests
@@ -19,8 +18,6 @@
 | DELETE | /batch/{batchID}                        | Deletes a batch.                                       | None                                             |
 | GET    | /projects/{projectID}/batches           | Returns all batches associated with a project as JSON. | None                                             |
 | DELETE | /projects/{projectID}/batches        | Deletes all batches associated with a project.         | None                                             |
-| PATCH  | /batch/{batchID}/numberofTotalFiles     | Increments the number of total files in a batch.       | { "quantity": int }                              |
-| PATCH  | /batch/{batchID}/numberofAnnotatedFiles | Increments the number of annotated files in a batch.   | { "quantity": int }                              |
 
 # Image Requests
 

--- a/src/services/golang-project-service/api/batch.go
+++ b/src/services/golang-project-service/api/batch.go
@@ -41,10 +41,6 @@ func RegisterBatchRoutes(r *mux.Router, h *handler.Handler) {
 		{"GET", "/batch/{batchID}", bh.LoadBatchHandler},
 		// Delete all batches associated with a project
 		{"DELETE", "/projects/{projectID}/batches", bh.DeleteAllBatchesHandler},
-		// Increment numberOfTotalFiles
-		{"PATCH", "/batch/{batchID}/numberofTotalFiles", bh.UpdateNumberOfTotalFilesHandler},
-		// Increment numberOfAnnotatedFiles
-		{"PATCH", "/batch/{batchID}/numberofAnnotatedFiles", bh.UpdateNumberOfAnnotatedFilesHandler},
 	}
 
 	for _, rt := range routes {
@@ -82,6 +78,13 @@ func (h *BatchHandler) LoadBatchesInfoHandler(w http.ResponseWriter, r *http.Req
 		http.Error(w, "Error getting batches", http.StatusInternalServerError)
 		log.Error().Err(err).Str("projectID", projectID).Msg("Failed to get batches by projectID")
 		return
+	}
+	for i, batch := range batches {
+		fileCount, err := h.ImageStore.GetTotalImageCountByBatchID(h.Ctx, batch.BatchID)
+		if err != nil {
+			log.Error().Err(err).Str("batchID", batch.BatchID).Msg("Failed to get total image count")
+		}
+		batches[i].NumberOfTotalFiles = fileCount
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -223,61 +226,5 @@ func (h *BatchHandler) DeleteAllBatchesHandler(w http.ResponseWriter, r *http.Re
 		"projectID": projectID,
 		"deleted":   true,
 		"message":   "All batches deleted",
-	})
-}
-
-func (h *BatchHandler) UpdateNumberOfTotalFilesHandler(w http.ResponseWriter, r *http.Request) {
-	vars := mux.Vars(r)
-	batchID := vars["batchID"]
-
-	var req firestore.IncrementQuantityRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "Invalid request", http.StatusBadRequest)
-		log.Error().Err(err).Str("batchID", batchID).Msg("Invalid update number of total files request")
-		return
-	}
-
-	newVal, err := h.BatchStore.IncrementNumberOfTotalFiles(h.Ctx, batchID, req)
-	if err != nil {
-		http.Error(w, "Error incrementing number of total files", http.StatusInternalServerError)
-		log.Error().Err(err).Str("batchID", batchID).Msg("Error incrementing number of total files")
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	log.Info().Str("batchID", batchID).Int64("newNumberOfTotalFiles", newVal).Msg("Updated number of total files successfully")
-	_ = json.NewEncoder(w).Encode(map[string]interface{}{
-		"batchID":            batchID,
-		"numberOfTotalFiles": newVal,
-		"message":            "Updated numberOfTotalFiles",
-	})
-}
-
-func (h *BatchHandler) UpdateNumberOfAnnotatedFilesHandler(w http.ResponseWriter, r *http.Request) {
-	vars := mux.Vars(r)
-	batchID := vars["batchID"]
-
-	var req firestore.IncrementQuantityRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "Invalid request", http.StatusBadRequest)
-		log.Error().Err(err).Str("batchID", batchID).Msg("Invalid update number of annotated files request")
-		return
-	}
-
-	newVal, err := h.BatchStore.IncrementNumberOfAnnotatedFiles(h.Ctx, batchID, req)
-	if err != nil {
-		http.Error(w, "Error incrementing number of annotated files", http.StatusInternalServerError)
-		log.Error().Err(err).Str("batchID", batchID).Msg("Error incrementing number of annotated files")
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	log.Info().Str("batchID", batchID).Int64("newNumberOfAnnotatedFiles", newVal).Msg("Updated number of annotated files successfully")
-	_ = json.NewEncoder(w).Encode(map[string]interface{}{
-		"batchID":                batchID,
-		"numberOfAnnotatedFiles": newVal,
-		"message":                "Updated numberOfAnnotatedFiles",
 	})
 }

--- a/src/services/golang-project-service/firestore/batch.go
+++ b/src/services/golang-project-service/firestore/batch.go
@@ -2,7 +2,6 @@ package firestore
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	fs "pkg/gcp/firestore"
@@ -20,11 +19,10 @@ const (
 )
 
 type Batch struct {
-	BatchID                string `firestore:"batchID,omitempty" json:"batchID"`
-	BatchName              string `firestore:"batchName,omitempty" json:"batchName"`
-	ProjectID              string `firestore:"projectID,omitempty" json:"projectID"`
-	NumberOfTotalFiles     int    `firestore:"numberOfTotalFiles,omitempty" json:"numberOfTotalFiles"`
-	NumberOfAnnotatedFiles int    `firestore:"numberOfAnnotatedFiles,omitempty" json:"numberOfAnnotatedFiles"`
+	BatchID            string `firestore:"batchID,omitempty" json:"batchID"`
+	BatchName          string `firestore:"batchName,omitempty" json:"batchName"`
+	ProjectID          string `firestore:"projectID,omitempty" json:"projectID"`
+	NumberOfTotalFiles int64  `firestore:"numberOfTotalFiles,omitempty" json:"numberOfTotalFiles"`
 }
 
 type CreateBatchRequest struct {
@@ -68,13 +66,18 @@ func (s *BatchStore) GetBatchesByProjectID(ctx context.Context, projectID string
 	return batches, nil
 }
 
+func (s *BatchStore) GetTotalBatchCountByProjectID(ctx context.Context, projectID string) (int64, error) {
+	queryParams := []fs.QueryParameter{
+		{Path: "projectID", Op: "==", Value: projectID},
+	}
+	return s.genericStore.GetAggregationWithQuery(ctx, queryParams, fs.Count)
+}
+
 func (s *BatchStore) CreateBatch(ctx context.Context, createBatchReq CreateBatchRequest) (string, error) {
 	batchData := map[string]interface{}{
-		"batchName":              createBatchReq.BatchName,
-		"projectID":              createBatchReq.ProjectID,
-		"lastUpdated":            time.Now(),
-		"numberOfTotalFiles":     0,
-		"numberOfAnnotatedFiles": 0,
+		"batchName":   createBatchReq.BatchName,
+		"projectID":   createBatchReq.ProjectID,
+		"lastUpdated": time.Now(),
 	}
 
 	return s.genericStore.CreateDoc(ctx, batchData)
@@ -127,48 +130,4 @@ func (s *BatchStore) ListBatchIDsByProjectID(ctx context.Context, projectID stri
 		ids = append(ids, b.BatchID)
 	}
 	return ids, nil
-}
-
-func (s *BatchStore) IncrementNumberOfTotalFiles(ctx context.Context, batchID string, req IncrementQuantityRequest) (int64, error) {
-	docSnap, err := s.genericStore.GetDoc(ctx, batchID)
-	if err != nil {
-		return 0, err
-	}
-	currentVal, err := docSnap.DataAt("numberOfTotalFiles")
-	if err != nil {
-		return 0, err
-	}
-	currentInt, ok := currentVal.(int64)
-	if !ok {
-		return 0, fmt.Errorf("invalid type for numberOfTotalFiles")
-	}
-
-	newVal := currentInt + int64(req.Quantity)
-	if newVal < 0 {
-		newVal = 0
-	}
-	err = s.genericStore.UpdateDoc(ctx, batchID, []firestore.Update{{Path: "numberOfTotalFiles", Value: newVal}})
-	return newVal, err
-}
-
-func (s *BatchStore) IncrementNumberOfAnnotatedFiles(ctx context.Context, batchID string, req IncrementQuantityRequest) (int64, error) {
-	docSnap, err := s.genericStore.GetDoc(ctx, batchID)
-	if err != nil {
-		return 0, err
-	}
-	currentVal, err := docSnap.DataAt("numberOfAnnotatedFiles")
-	if err != nil {
-		return 0, err
-	}
-	currentInt, ok := currentVal.(int64)
-	if !ok {
-		return 0, fmt.Errorf("invalid type for numberOfAnnotatedFiles")
-	}
-
-	newVal := currentInt + int64(req.Quantity)
-	if newVal < 0 {
-		newVal = 0
-	}
-	err = s.genericStore.UpdateDoc(ctx, batchID, []firestore.Update{{Path: "numberOfAnnotatedFiles", Value: newVal}})
-	return newVal, err
 }

--- a/src/services/golang-project-service/firestore/image.go
+++ b/src/services/golang-project-service/firestore/image.go
@@ -68,6 +68,13 @@ func (s *ImageStore) GetImagesByBatchID(ctx context.Context, batchID string) ([]
 	return images, nil
 }
 
+func (s *ImageStore) GetTotalImageCountByBatchID(ctx context.Context, batchID string) (int64, error) {
+	queryParams := []fs.QueryParameter{
+		{Path: "batchID", Op: "==", Value: batchID},
+	}
+	return s.genericStore.GetAggregationWithQuery(ctx, queryParams, fs.Count)
+}
+
 func (s *ImageStore) CreateImageMetadata(ctx context.Context, batchID string, imageInfo map[string]string) error {
 	var batch []interface{}
 	for imageName, imageURL := range imageInfo {

--- a/src/services/golang-project-service/firestore/project.go
+++ b/src/services/golang-project-service/firestore/project.go
@@ -2,7 +2,6 @@ package firestore
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	fs "pkg/gcp/firestore"
@@ -15,12 +14,12 @@ const (
 )
 
 type Project struct {
-	ProjectID     string          `firestore:"projectID,omitempty" json:"projectID"`
-	ProjectName   string          `firestore:"projectName,omitempty" json:"projectName"`
-	UserID        string          `firestore:"userID,omitempty" json:"userID"`
-	NumberOfFiles int             `firestore:"numberOfFiles,omitempty" json:"numberOfFiles"`
-	LastUpdated   time.Time       `firestore:"lastUpdated,omitempty" json:"lastUpdated"`
-	Settings      ProjectSettings `firestore:"settings,omitempty" json:"settings"`
+	ProjectID       string          `firestore:"projectID,omitempty" json:"projectID"`
+	ProjectName     string          `firestore:"projectName,omitempty" json:"projectName"`
+	UserID          string          `firestore:"userID,omitempty" json:"userID"`
+	NumberOfBatches int64           `firestore:"numberOfBatches,omitempty" json:"numberOfBatches"`
+	LastUpdated     time.Time       `firestore:"lastUpdated,omitempty" json:"lastUpdated"`
+	Settings        ProjectSettings `firestore:"settings,omitempty" json:"settings"`
 }
 
 type ProjectSettings struct {
@@ -95,10 +94,9 @@ func (s *ProjectStore) GetProject(ctx context.Context, projectID string) (*Proje
 
 func (s *ProjectStore) CreateProject(ctx context.Context, createProjectReq CreateProjectRequest) (string, error) {
 	project := Project{
-		ProjectName:   createProjectReq.ProjectName,
-		UserID:        createProjectReq.UserID,
-		NumberOfFiles: 0,
-		LastUpdated:   time.Now(),
+		ProjectName: createProjectReq.ProjectName,
+		UserID:      createProjectReq.UserID,
+		LastUpdated: time.Now(),
 	}
 
 	return s.genericStore.CreateDoc(ctx, project)
@@ -116,28 +114,6 @@ func (s *ProjectStore) RenameProject(ctx context.Context, projectID string, rena
 
 func (s *ProjectStore) DeleteProject(ctx context.Context, projectID string) error {
 	return s.genericStore.DeleteDoc(ctx, projectID)
-}
-
-func (s *ProjectStore) IncrementNumberOfFiles(ctx context.Context, projectID string, req IncrementQuantityRequest) (int64, error) {
-	docSnap, err := s.genericStore.GetDoc(ctx, projectID)
-	if err != nil {
-		return 0, err
-	}
-	currentVal, err := docSnap.DataAt("numberOfFiles")
-	if err != nil {
-		return 0, err
-	}
-	currentInt, ok := currentVal.(int64)
-	if !ok {
-		return 0, fmt.Errorf("invalid type for numberOfFiles")
-	}
-
-	newVal := currentInt + int64(req.Quantity)
-	if newVal < 0 {
-		newVal = 0
-	}
-	err = s.genericStore.UpdateDoc(ctx, projectID, []firestore.Update{{Path: "numberOfFiles", Value: newVal}})
-	return newVal, err
 }
 
 func (s *ProjectStore) UpdateProjectSettings(ctx context.Context, projectID string, req ProjectSettings) (*ProjectSettings, error) {


### PR DESCRIPTION
The number of batches in a project and the number of images in a batch are calculated using an aggregated query to firestore each time the API is called.

This avoids having to do extra logic each time an image or batch is created.

It shouldn't have that much of a query cost increase as 1 read operation is charged for each batch of 1000 index entry reads. https://firebase.google.com/docs/firestore/query-data/aggregation-queries